### PR TITLE
fix: EC2 key pair 생성 제거

### DIFF
--- a/env/stg/apne2/devops/.terraform.lock.hcl
+++ b/env/stg/apne2/devops/.terraform.lock.hcl
@@ -25,26 +25,6 @@ provider "registry.terraform.io/hashicorp/aws" {
   ]
 }
 
-provider "registry.terraform.io/hashicorp/local" {
-  version = "2.5.2"
-  hashes = [
-    "h1:6NIiHWMbE9bFZaUiqC+OokdWSbW7g3+yQYnO4yvgtuY=",
-    "h1:IyFbOIO6mhikFNL/2h1iZJ6kyN3U00jgkpCLUCThAfE=",
-    "zh:136299545178ce281c56f36965bf91c35407c11897f7082b3b983d86cb79b511",
-    "zh:3b4486858aa9cb8163378722b642c57c529b6c64bfbfc9461d940a84cd66ebea",
-    "zh:4855ee628ead847741aa4f4fc9bed50cfdbf197f2912775dd9fe7bc43fa077c0",
-    "zh:4b8cd2583d1edcac4011caafe8afb7a95e8110a607a1d5fb87d921178074a69b",
-    "zh:52084ddaff8c8cd3f9e7bcb7ce4dc1eab00602912c96da43c29b4762dc376038",
-    "zh:71562d330d3f92d79b2952ffdda0dad167e952e46200c767dd30c6af8d7c0ed3",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:805f81ade06ff68fa8b908d31892eaed5c180ae031c77ad35f82cb7a74b97cf4",
-    "zh:8b6b3ebeaaa8e38dd04e56996abe80db9be6f4c1df75ac3cccc77642899bd464",
-    "zh:ad07750576b99248037b897de71113cc19b1a8d0bc235eb99173cc83d0de3b1b",
-    "zh:b9f1c3bfadb74068f5c205292badb0661e17ac05eb23bfe8bd809691e4583d0e",
-    "zh:cc4cbcd67414fefb111c1bf7ab0bc4beb8c0b553d01719ad17de9a047adff4d1",
-  ]
-}
-
 provider "registry.terraform.io/hashicorp/random" {
   version     = "3.7.1"
   constraints = ">= 3.5.1"
@@ -63,25 +43,5 @@ provider "registry.terraform.io/hashicorp/random" {
     "zh:b7d3af018683ef22794eea9c218bc72d7c35a2b3ede9233b69653b3c782ee436",
     "zh:d63b911d618a6fe446c65bfc21e793a7663e934b2fef833d42d3ccd38dd8d68d",
     "zh:fa985cd0b11e6d651f47cff3055f0a9fd085ec190b6dbe99bf5448174434cdea",
-  ]
-}
-
-provider "registry.terraform.io/hashicorp/tls" {
-  version = "4.0.6"
-  hashes = [
-    "h1:17Y+vdYNKgphpe1/SU5PBnGuYKEJkJZ7MZCnmAwsAGQ=",
-    "h1:n3M50qfWfRSpQV9Pwcvuse03pEizqrmYEryxKky4so4=",
-    "zh:10de0d8af02f2e578101688fd334da3849f56ea91b0d9bd5b1f7a243417fdda8",
-    "zh:37fc01f8b2bc9d5b055dc3e78bfd1beb7c42cfb776a4c81106e19c8911366297",
-    "zh:4578ca03d1dd0b7f572d96bd03f744be24c726bfd282173d54b100fd221608bb",
-    "zh:6c475491d1250050765a91a493ef330adc24689e8837a0f07da5a0e1269e11c1",
-    "zh:81bde94d53cdababa5b376bbc6947668be4c45ab655de7aa2e8e4736dfd52509",
-    "zh:abdce260840b7b050c4e401d4f75c7a199fafe58a8b213947a258f75ac18b3e8",
-    "zh:b754cebfc5184873840f16a642a7c9ef78c34dc246a8ae29e056c79939963c7a",
-    "zh:c928b66086078f9917aef0eec15982f2e337914c5c4dbc31dd4741403db7eb18",
-    "zh:cded27bee5f24de6f2ee0cfd1df46a7f88e84aaffc2ecbf3ff7094160f193d50",
-    "zh:d65eb3867e8f69aaf1b8bb53bd637c99c6b649ba3db16ded50fa9a01076d1a27",
-    "zh:ecb0c8b528c7a619fa71852bb3fb5c151d47576c5aab2bf3af4db52588722eeb",
-    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }

--- a/env/stg/apne2/devops/terraform.tfvars
+++ b/env/stg/apne2/devops/terraform.tfvars
@@ -832,18 +832,12 @@ ec2_security_group_id = {}
 # EC2 key pair
 ec2_key_pair = {
   search-opensearch-key = {
-    key_pair_name         = "search-opensearch-key"
-    key_pair_algorithm    = "RSA"
-    rsa_bits              = 4096
-    local_file_name       = "keypair/search-opensearch-key.pem" # terraform key pair 생성 후 저장 경로 modules/aws/compute/ec2/...
-    local_file_permission = "0600"                              # 6(read + writer)00
+    name = "search-opensearch-key"
+    env  = "stg"
   },
   search-atlantis-key = {
-    key_pair_name         = "search-atlantis-key"
-    key_pair_algorithm    = "RSA"
-    rsa_bits              = 4096
-    local_file_name       = "keypair/search-atlantis-key.pem"
-    local_file_permission = "0600"
+    name = "search-atlantis-key"
+    env  = "stg"
   }
 }
 

--- a/env/stg/apne2/devops/variables.tf
+++ b/env/stg/apne2/devops/variables.tf
@@ -472,11 +472,8 @@ variable "ec2_security_group_id" {
 variable "ec2_key_pair" {
   description = "EC2 key pair"
   type = map(object({
-    key_pair_name         = string
-    key_pair_algorithm    = string
-    rsa_bits              = string
-    local_file_name       = string
-    local_file_permission = string
+    name = string
+    env  = string
   }))
 }
 

--- a/modules/aws/compute/ec2/main.tf
+++ b/modules/aws/compute/ec2/main.tf
@@ -15,6 +15,17 @@ data "aws_ami" "amazon_ami" {
   }
 }
 
+# EC2 key pair
+data "aws_key_pair" "key_pair" {
+  for_each = var.ec2_key_pair
+
+  key_name = each.value.name
+
+  tags = merge(var.tags, {
+    Name = "${each.value.name}-${each.value.env}"
+  })
+}
+
 # EC2 instance
 resource "aws_instance" "ec2" {
   for_each = var.ec2_instance
@@ -37,7 +48,7 @@ resource "aws_instance" "ec2" {
   associate_public_ip_address = each.value.associate_public_ip_address # 퍼블릭 IP 할당 여부 지정(true면 공인 IP 부여 -> 고정 IP 아님)
   disable_api_termination     = each.value.disable_api_termination     # TRUE인 경우 콘솔/API로 삭제 불가
 
-  key_name = aws_key_pair.ec2_key_pair[each.value.key_pair_name].key_name # SSH key pair 지정
+  key_name = data.aws_key_pair.key_pair[each.value.key_pair_name].key_name # SSH key pair 지정
 
   vpc_security_group_ids = [ # 인스턴스에 지정될 보안그룹 ID 지정
     var.ec2_security_group_id[each.value.security_group_name]
@@ -67,29 +78,4 @@ resource "aws_instance" "ec2" {
   tags = merge(var.tags, {
     Name = "${each.value.instance_name}-${each.value.env}"
   })
-}
-
-# EC2 key pair Decide encryption method + generate a TLS/SSL private key
-resource "tls_private_key" "ec2_key_pair_rsa" {
-  for_each = var.ec2_key_pair
-
-  algorithm = each.value.key_pair_algorithm # RSA 알고리즘 설정
-  rsa_bits  = each.value.rsa_bits           # RSA 키 길이를 4096 bit로 설정 (4096 => 보안성 높은 설정 값, default => 2048)
-}
-
-# EC2 key pair
-resource "aws_key_pair" "ec2_key_pair" {
-  for_each = var.ec2_key_pair
-
-  key_name   = each.value.key_pair_name
-  public_key = tls_private_key.ec2_key_pair_rsa[each.key].public_key_openssh # Terraform이 생성한 RSA키의 공개 키를 가져와 EC2 SSH 키 페어로 등록
-}
-
-# EC2 key pair to save local file
-resource "local_file" "ec2_key_pair_local_file" {
-  for_each = var.ec2_key_pair
-
-  content         = tls_private_key.ec2_key_pair_rsa[each.key].private_key_pem
-  filename        = "${path.module}/${each.value.local_file_name}"
-  file_permission = each.value.local_file_permission
 }

--- a/modules/aws/compute/ec2/variables.tf
+++ b/modules/aws/compute/ec2/variables.tf
@@ -90,11 +90,8 @@ variable "ec2_security_group_id" {
 variable "ec2_key_pair" {
   description = "EC2 key pair"
   type = map(object({
-    key_pair_name         = string
-    key_pair_algorithm    = string
-    rsa_bits              = string
-    local_file_name       = string
-    local_file_permission = string
+    name = string
+    env  = string
   }))
 }
 


### PR DESCRIPTION
#33 
1. key pair의 경우 콘솔에서 수동 생성 후, data 참조하는 방식으로 수정